### PR TITLE
Fix segfault that can occur after a large number of turns

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -31,6 +31,21 @@ end
   @world.seed_player(pos: STARTING[index], seed: morphogen.seed, char: char)
 end
 
+# text objects for player stats
+@player_stats = {}
+y = 0
+default = { size: FONT_SIZE, font: FONT, x: FULL_WIDTH - SIDEBAR }
+@morphogens.each do |char, morphogen|
+  @player_stats[morphogen.name] = {
+    name: Text.new(default.merge(y: y, text: morphogen.name, color: morphogen.color)),
+    score: Text.new(default.merge(y: y + FONT_SIZE, text: "score: #{@world.player_score(char)}", color: 'white'))
+  }
+  y += FONT_SIZE * 3
+end
+
+# text object for displaying the number of turns
+@turns_counter = Text.new(default.merge(y: y + FONT_SIZE, text: "turns: #{@world.turns}", color: 'white'))
+
 def make_moves
   morphogen = @morphogens_enumerator.next[1]
   moves = morphogen.moves(@world.state)
@@ -38,15 +53,14 @@ def make_moves
   @world.set_player(player: morphogen.char, pos: moves[1])
 end
 
-def render_scoreboard
-  y = 0
-  default = { size: FONT_SIZE, font: FONT, x: FULL_WIDTH - SIDEBAR }
+def update_scoreboard
   @morphogens.each do |char, morphogen|
-    score = @world.player_score(char)
-    Text.new(default.merge(y: y, text: morphogen.name, color: morphogen.color))
-    Text.new(default.merge(y: y + FONT_SIZE, text: "score: #{score}", color: 'white'))
-    y += FONT_SIZE * 3
+    @player_stats[morphogen.name][:score].text = "score: #{@world.player_score(char)}"
+    @player_stats[morphogen.name][:score].add
+    @player_stats[morphogen.name][:name].add
   end
+  @turns_counter.text = "turns: #{@world.turns}"
+  @turns_counter.add
 end
 
 set title: 'Biotic', width: FULL_WIDTH, height: FULL_HEIGHT
@@ -67,7 +81,7 @@ def redraw
   clear
   make_moves
   render_world
-  render_scoreboard
+  update_scoreboard
   @world.iterate
 end
 

--- a/app.rb
+++ b/app.rb
@@ -43,9 +43,6 @@ default = { size: FONT_SIZE, font: FONT, x: FULL_WIDTH - SIDEBAR }
   y += FONT_SIZE * 3
 end
 
-# text object for displaying the number of turns
-@turns_counter = Text.new(default.merge(y: y + FONT_SIZE, text: "turns: #{@world.turns}", color: 'white'))
-
 def make_moves
   morphogen = @morphogens_enumerator.next[1]
   moves = morphogen.moves(@world.state)
@@ -59,8 +56,6 @@ def update_scoreboard
     @player_stats[morphogen.name][:score].add
     @player_stats[morphogen.name][:name].add
   end
-  @turns_counter.text = "turns: #{@world.turns}"
-  @turns_counter.add
 end
 
 set title: 'Biotic', width: FULL_WIDTH, height: FULL_HEIGHT


### PR DESCRIPTION
System details:
> MacOS 10.13.6
> MRI 2.5.1
> ruby2d 0.5.1
> simple2d 1.0.1 (from homebrew)

Using morphogen code like:

```ruby
def moves(world_state)
  world_state.chars.each_with_index do |cell, idx|
  if cell != @char && cell != ' '
    if world_state.neighborhood(idx).all?{|c| c == ' '}
      return [idx-1, idx+1]
    end
  end
end
```

I could reliably get `app.rb` to segfault after a few hundred moves:

```
/Users/mnielsen/.rvm/gems/ruby-2.5.1/gems/ruby2d-0.5.1/lib/ruby2d/text.rb:26: [BUG] Segmentation fault at 0x0000000000000040
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:                    
     * ~/Library/Logs/DiagnosticReports                                     
     * /Library/Logs/DiagnosticReports                                      
   for more details.                                                        
Don't forget to include the above Crash Report log file in bug reports.     

-- Control frame information -----------------------------------------------
c:0015 p:---- s:0063 e:000062 CFUNC  :ext_init
c:0014 p:0175 s:0059 e:000058 METHOD /Users/mnielsen/.rvm/gems/ruby-2.5.1/gems/ruby2d-0.5.1/lib/ruby2d/text.rb:26 [FINISH]
c:0013 p:---- s:0054 e:000053 CFUNC  :new
c:0012 p:0038 s:0049 e:000048 BLOCK  app.rb:60 [FINISH]
c:0011 p:---- s:0043 e:000042 CFUNC  :each
c:0010 p:0051 s:0039 e:000038 METHOD app.rb:58
c:0009 p:0019 s:0033 e:000032 METHOD app.rb:114
c:0008 p:0005 s:0029 e:000028 BLOCK  app.rb:121 [FINISH]
c:0007 p:0006 s:0026 e:000025 METHOD /Users/mnielsen/.rvm/gems/ruby-2.5.1/gems/ruby2d-0.5.1/lib/ruby2d/window.rb:234 [FINISH]
c:0006 p:---- s:0022 e:000021 CFUNC  :ext_show
c:0005 p:0004 s:0018 e:000017 METHOD /Users/mnielsen/.rvm/gems/ruby-2.5.1/gems/ruby2d-0.5.1/lib/ruby2d/window.rb:238
c:0004 p:0005 s:0014 e:000013 METHOD /Users/mnielsen/.rvm/gems/ruby-2.5.1/gems/ruby2d-0.5.1/lib/ruby2d/application.rb:40
c:0003 p:0010 s:0010 e:000009 METHOD /Users/mnielsen/.rvm/gems/ruby-2.5.1/gems/ruby2d-0.5.1/lib/ruby2d/dsl.rb:29
c:0002 p:0301 s:0006 E:0014b0 EVAL   app.rb:123 [FINISH]
c:0001 p:0000 s:0003 E:000f70 (none) [FINISH]
```

I had read about [memory leaks in Ruby2D's text object initializer](https://github.com/ruby2d/ruby2d/issues/35) and so this PR avoids extra`Text.new` calls:

  * It creates the scoreboard text objects only once when the app is first run (`app.rb#34`)
  * Replaces `render_scoreboard` with `update_scoreboard` that updates contents of each Text object and adds them to the current frame.

With this change I have been able to run the above morphogen code for 10K+ iterations without a segfault.