### PR TITLE
Make sure Simple morphogen doesn't attempt to move out-of-bounds

### DIFF
--- a/morphogens/simple.rb
+++ b/morphogens/simple.rb
@@ -34,6 +34,6 @@ class Simple
       world_state.sw(pos),
       world_state.w(pos),
       world_state.nw(pos)
-    ].sample(2)
+    ].reject(&:negative?).reject{|pos| pos > world_state.size}.sample(2)
   end
 end


### PR DESCRIPTION
Simple could eventually try for positon `-1` which will raise `InvalidPosition`, we prevent that.

Note: there is a `test/simple_morphogen_test.rb` file but I don't know if that is for testing *this* morphogen or just a "simple test example", so Ieft it alone for now 🤷‍♀️  